### PR TITLE
Change elytra speed boost config to a multiplier, and add option to d…

### DIFF
--- a/src/main/java/genandnic/walljump/Config.java
+++ b/src/main/java/genandnic/walljump/Config.java
@@ -33,11 +33,14 @@ public class Config {
                     .comment("Automatically turn the player when wall clinging")
                     .define("autoRotation", false);
             this.elytraSpeedBoost = builder
-                    .comment("Elytra speed boost; set to 0.0 to disable")
-                    .defineInRange("elytraSpeedBoost", 0.0, 0.0, 5.0);
+                    .comment("Elytra speed boost multiplier")
+                    .defineInRange("elytraSpeedBoost", 1.0, 0.0, 5.0);
             this.enableEnchantments = builder
                     .comment("Enable Wall-Jump enchantments in the enchanting table")
                     .define("enableEnchantments",true);
+            this.enableElytraSpeedEnchantment = builder
+                    .comment("Enable the Speed Boost enchantment for elytra")
+                    .define("enableElytraSpeedEnchantment",true);
             this.exhaustionWallJump = builder
                     .comment("Exhaustion gained per wall jump")
                     .defineInRange("exhaustionWallJump", 0.8, 0.0, 5.0);

--- a/src/main/java/genandnic/walljump/Config.java
+++ b/src/main/java/genandnic/walljump/Config.java
@@ -13,6 +13,7 @@ public class Config {
         public final ForgeConfigSpec.BooleanValue autoRotation;
         public final ForgeConfigSpec.DoubleValue elytraSpeedBoost;
         public final ForgeConfigSpec.BooleanValue enableEnchantments;
+        public final ForgeConfigSpec.BooleanValue enableElytraSpeedEnchantment;
         public final ForgeConfigSpec.DoubleValue exhaustionWallJump;
         public final ForgeConfigSpec.DoubleValue minFallDistance;
         public final ForgeConfigSpec.BooleanValue playFallSound;

--- a/src/main/java/genandnic/walljump/client/SpeedBoostLogic.java
+++ b/src/main/java/genandnic/walljump/client/SpeedBoostLogic.java
@@ -39,7 +39,7 @@ public class SpeedBoostLogic {
 
             } else if (pl.isSprinting()) {
 
-                float elytraSpeedBoost = Config.COMMON.elytraSpeedBoost.get().floatValue() + (getEquipmentBoost(pl, EquipmentSlot.CHEST) * 0.5f);
+                float elytraSpeedBoost = Config.COMMON.elytraSpeedBoost.get().floatValue() * (getEquipmentBoost(pl, EquipmentSlot.CHEST) * 0.5f);
                 Vec3 boost = new Vec3(look.x, look.y, look.z).normalize().scale(elytraSpeedBoost);
                 if (motion.length() <= boost.length()) {
                     pl.setDeltaMovement(motion.add(boost.multiply(0.05, 0.05, 0.05)));

--- a/src/main/java/genandnic/walljump/enchantment/SpeedBoostEnchant.java
+++ b/src/main/java/genandnic/walljump/enchantment/SpeedBoostEnchant.java
@@ -37,7 +37,7 @@ public class SpeedBoostEnchant extends Enchantment {
 
     @Override
     public boolean canEnchant(ItemStack stack) {
-        return super.canEnchant(stack) || stack.getItem() instanceof ElytraItem;
+        return super.canEnchant(stack) || (stack.getItem() instanceof ElytraItem && Config.COMMON.enableElytraSpeedEnchantment.get());
     }
 
     @Override


### PR DESCRIPTION
…isable entirely

Based on the config tooltip, I think there may be a bug in the implementation of the elytra's speed boost, because setting it to 0.0 (the default) still adds a boost. I changed it to be a multiplier, and updated the default from 0.0 to 1.0 so that the default behavior remains the same.

I also added a config option to disable the Speed Boost enchantment for elytra entirely, as some users expressed that it renders most other modes of transport obsolete, without an easy way to add drawbacks for balance.